### PR TITLE
Add goimport sample project and car package

### DIFF
--- a/goimport-master/README.md
+++ b/goimport-master/README.md
@@ -1,0 +1,59 @@
+# goimport
+The test for import on golang.
+
+## Environment
+```ShellSession
+$ go version
+go version go1.14.2 darwin/amd64
+
+$ echo $GO111MODULE
+on
+```
+
+## Tree
+```ShellSession
+$ tree $GOPATH/src/github.com/kotaoue/goimport -L 3
+/$GOPATH/src/github.com/kotaoue/goimport
+├── LICENSE
+├── README.md
+├── go.mod
+├── go.sum
+├── main.go
+└── packages
+    └── car
+        ├── car.go
+        └── go.mod
+```
+
+## cf.
+* https://github.com/golang/go/wiki/Modules#quick-start-example
+* https://github.com/golang/go/wiki/Modules#when-should-i-use-the-replace-directive
+
+## Command logs
+```ShellSession
+$ cd $GOPATH/src/github.com/kotaoue/goimport/packages/car
+$ go mod init
+
+$ cd $GOPATH/src/github.com/kotaoue/goimport/
+$ go mod init github.com/kotaoue/goimport
+$ go mod edit -replace github.com/kotaoue/goimport/packages/car=./packages/car
+
+# When build completed a require for "packages/car" are attached on "go.mod".
+$ go build main.go
+
+$ go list -m all
+github.com/kotaoue/goimport
+github.com/kotaoue/goimport/packages/car v0.0.0-00010101000000-000000000000 => ./packages/car
+golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c
+rsc.io/quote v1.5.2
+rsc.io/sampler v1.3.0
+```
+
+## Result
+```ShellSession
+$ go run main.go 
+2020/06/24 10:51:27 Start
+2020/06/24 10:51:27 こんにちは世界。
+2020/06/24 10:51:27 vroom!!
+2020/06/24 10:51:27 End
+```

--- a/goimport-master/go.mod
+++ b/goimport-master/go.mod
@@ -1,0 +1,10 @@
+module github.com/kotaoue/goimport
+
+go 1.14
+
+require (
+	github.com/kotaoue/goimport/packages/car v0.0.0-00010101000000-000000000000 // indirect
+	rsc.io/quote v1.5.2
+)
+
+replace github.com/kotaoue/goimport/packages/car => ./packages/car

--- a/goimport-master/go.sum
+++ b/goimport-master/go.sum
@@ -1,0 +1,6 @@
+golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c h1:qgOY6WgZOaTkIIMiVjBQcw93ERBE4m30iBm00nkL0i8=
+golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+rsc.io/quote v1.5.2 h1:w5fcysjrx7yqtD/aO+QwRjYZOKnaM9Uh2b40tElTs3Y=
+rsc.io/quote v1.5.2/go.mod h1:LzX7hefJvL54yjefDEDHNONDjII0t9xZLPXsUe+TKr0=
+rsc.io/sampler v1.3.0 h1:7uVkIFmeBqHfdjD+gZwtXXI+RODJ2Wc4O7MPEh/QiW4=
+rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=

--- a/goimport-master/main.go
+++ b/goimport-master/main.go
@@ -1,0 +1,15 @@
+package main
+
+import (
+	"log"
+
+	"github.com/kotaoue/goimport/packages/car"
+	"rsc.io/quote"
+)
+
+func main() {
+	log.Println("Start")
+	log.Println(quote.Hello())
+	log.Println(car.Ignition())
+	log.Println("End")
+}

--- a/goimport-master/packages/car/car.go
+++ b/goimport-master/packages/car/car.go
@@ -1,0 +1,5 @@
+package car
+
+func Ignition() string {
+	return "vroom!!"
+}

--- a/goimport-master/packages/car/go.mod
+++ b/goimport-master/packages/car/go.mod
@@ -1,0 +1,3 @@
+module github.com/kotaoue/goimport/packages/car
+
+go 1.14


### PR DESCRIPTION
Create a sample Go module 'github.com/kotaoue/goimport' demonstrating module imports and a local replace. Adds main.go (uses rsc.io/quote and the local packages/car module), packages/car with its own go.mod and Ignition() function, and a README documenting usage and module layout. Root go.mod includes a replace directive to point the local package module to ./packages/car.